### PR TITLE
身長をゲーム内設定から自動的に取得するオプションを追加

### DIFF
--- a/NoteCenterVisualizer/Menu/SettingsViewController.cs
+++ b/NoteCenterVisualizer/Menu/SettingsViewController.cs
@@ -30,11 +30,28 @@ namespace NoteCenterVisualizer.Menu
             set => PluginConfig.Instance.InMenu = value;
         }
 
+        [UIValue("AutoSetHeight")]
+        public bool AutoSetHeight
+        {
+            get => PluginConfig.Instance.AutoSetHeight;
+            set
+            {
+                PluginConfig.Instance.AutoSetHeight = value;
+                NotifyPropertyChanged(nameof(MyHeightActive));
+            }
+        }
+
         [UIValue("MyHeight")]
         public float MyHeight
         {
             get => PluginConfig.Instance.MyHeight;
             set => PluginConfig.Instance.MyHeight = value;
+        }
+
+        [UIValue("MyHeightActive")]
+        public bool MyHeightActive
+        {
+            get => !PluginConfig.Instance.AutoSetHeight;
         }
 
         [UIValue("ZPosition")]
@@ -74,6 +91,14 @@ namespace NoteCenterVisualizer.Menu
 
             SphereController.Instance.RefreshSpheres(isMenuScreen: true);
             SphereController.Instance.RefreshPlane(isMenuScreen: true);
+        }
+
+        [UIAction("ChangeAutoSetHeight")]
+        protected void ChangeAutoSetHeight(bool value)
+        {
+            PluginConfig.Instance.AutoSetHeight = value;
+
+            SphereController.Instance.RefreshSpheres(isMenuScreen: true);
         }
 
         [UIAction("ChangeHeight")]

--- a/NoteCenterVisualizer/Menu/settingsView.bsml
+++ b/NoteCenterVisualizer/Menu/settingsView.bsml
@@ -5,12 +5,17 @@
 		
 		<toggle-setting value="InGame" text="In Game" apply-on-change="true" 
 						hover-hint="Whether or not to display the ball during play"/>
-		
+
 		<toggle-setting value="InMenu" text="In Menu" apply-on-change="true" on-change="ChangeInMenu"
 						hover-hint="Whether to display the sphere on the menu screen"/>
-		
-		<increment-setting value="MyHeight" text="Height" min="1.4" max="1.8" increment="0.01" 
-						   apply-on-change="true" on-change="ChangeHeight" hover-hint="Height setting"/>
+
+		<toggle-setting value="AutoSetHeight" text="Auto Height" apply-on-change="true" on-change="ChangeAutoSetHeight"
+						hover-hint="Whether to get the player height from in-game settings. Disable it to set the player height manually."/>
+
+		<vertical vertical-fit="PreferredSize" pad-left="3">
+			<increment-setting value="MyHeight" text="Height" min="1.4" max="1.8" increment="0.01"
+							   apply-on-change="true" on-change="ChangeHeight" hover-hint="Height setting" active="~MyHeightActive"/>
+		</vertical>
 		
 		<increment-setting value="ZPosition" text="Z Position" min="0.5" max="1.5" increment="0.01" 
 						   apply-on-change="true" on-change="ChangeZPosition" hover-hint="Adjust sphere display position (Z coordinate)"/>

--- a/NoteCenterVisualizer/NoteCenterVisualizer.csproj
+++ b/NoteCenterVisualizer/NoteCenterVisualizer.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Menu\NoteCenterVisualizerFlowCoordinator.cs" />
     <Compile Include="Menu\SettingsViewController.cs" />
     <Compile Include="Patches\MainFlowCoordinatorPatch.cs" />
+    <Compile Include="Patches\PlayerHeightSettingsControllerPatch.cs" />
     <Compile Include="Patches\SoloFreePlayFlowCoordinatorPatch.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="PluginConfig.cs" />

--- a/NoteCenterVisualizer/Patches/PlayerHeightSettingsControllerPatch.cs
+++ b/NoteCenterVisualizer/Patches/PlayerHeightSettingsControllerPatch.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using NoteCenterVisualizer.SphereModule;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NoteCenterVisualizer.Patches
+{
+	[HarmonyPatch(typeof(PlayerHeightSettingsController), "RefreshUI")]
+	internal class PlayerHeightSettingsControllerPatch
+	{
+		static void Postfix(PlayerHeightSettingsController __instance)
+		{
+			SphereController.Instance.GameHeight = __instance.value;
+			if (PluginConfig.Instance.AutoSetHeight)
+			{
+				SphereController.Instance.RefreshSpheres(isMenuScreen: true);
+			}
+		}
+	}
+}

--- a/NoteCenterVisualizer/PluginConfig.cs
+++ b/NoteCenterVisualizer/PluginConfig.cs
@@ -17,7 +17,9 @@ namespace NoteCenterVisualizer
                 
         public virtual bool InMenu { get; set; } = true;
 
-        public virtual float MyHeight { get; set; } = 170f;
+        public virtual bool AutoSetHeight { get; set; } = true;
+
+		public virtual float MyHeight { get; set; } = 170f;
 
         public virtual float ZPosition { get; set; } = 0.9f;
 

--- a/NoteCenterVisualizer/SphereModule/SphereController.cs
+++ b/NoteCenterVisualizer/SphereModule/SphereController.cs
@@ -16,6 +16,8 @@ namespace NoteCenterVisualizer.SphereModule
         private GameObject frontPlane;
         private GameObject floorPlane;
 
+        public float GameHeight { get; set; } = 0.0f;
+
         public void RefreshSpheres(bool isMenuScreen)
         {
 
@@ -63,7 +65,8 @@ namespace NoteCenterVisualizer.SphereModule
             {
                 foreach (var y in yBasePositions)
                 {
-                    float yPosition = y + (PluginConfig.Instance.MyHeight / 2f);
+                    var playerHeight = PluginConfig.Instance.AutoSetHeight ? GameHeight : PluginConfig.Instance.MyHeight;
+                    float yPosition = y + (playerHeight / 2f);
 
                     var obj = GameObject.CreatePrimitive(PrimitiveType.Sphere);
 


### PR DESCRIPTION
- 設定画面に、Heightを自動的に取得する `Auto Height` オプションを追加
- `Auto Height` が有効の場合は、 `RefreshSpheres` で計算する身長をゲーム内から取得して位置を計算する。無効の場合は以前と同様に設定値から計算する。